### PR TITLE
Fixed HTML typo (infowindow)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,5 @@
 
 # Mac filesystem dust
 /.DS_Store
+
+*.iml

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.dynmap</groupId>
   <artifactId>Dynmap-GriefPrevention</artifactId>
-  <version>0.80</version>
+  <version>0.81</version>
   
     <build>
   	  <resources>

--- a/pom.xml
+++ b/pom.xml
@@ -23,15 +23,15 @@
 		  </excludes>
 		</resource>
 	  </resources>
-  
+
   	<plugins>
  			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.0.2</version>
+				<version>3.8.1</version>
 				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
    	</plugins>

--- a/src/main/java/org/dynmap/griefprevention/DynmapGriefPreventionPlugin.java
+++ b/src/main/java/org/dynmap/griefprevention/DynmapGriefPreventionPlugin.java
@@ -32,7 +32,7 @@ import org.dynmap.markers.MarkerSet;
 
 public class DynmapGriefPreventionPlugin extends JavaPlugin {
     private static Logger log;
-    private static final String DEF_INFOWINDOW = "div class=\"infowindow\">Claim Owner: <span style=\"font-weight:bold;\">%owner%</span><br/>Permission Trust: <span style=\"font-weight:bold;\">%managers%</span><br/>Trust: <span style=\"font-weight:bold;\">%builders%</span><br/>Container Trust: <span style=\"font-weight:bold;\">%containers%</span><br/>Access Trust: <span style=\"font-weight:bold;\">%accessors%</span></div>";
+    private static final String DEF_INFOWINDOW = "<div class=\"infowindow\">Claim Owner: <span style=\"font-weight:bold;\">%owner%</span><br/>Permission Trust: <span style=\"font-weight:bold;\">%managers%</span><br/>Trust: <span style=\"font-weight:bold;\">%builders%</span><br/>Container Trust: <span style=\"font-weight:bold;\">%containers%</span><br/>Access Trust: <span style=\"font-weight:bold;\">%accessors%</span></div>";
     private static final String DEF_ADMININFOWINDOW = "<div class=\"infowindow\"><span style=\"font-weight:bold;\">Administrator Claim</span><br/>Permission Trust: <span style=\"font-weight:bold;\">%managers%</span><br/>Trust: <span style=\"font-weight:bold;\">%builders%</span><br/>Container Trust: <span style=\"font-weight:bold;\">%containers%</span><br/>Access Trust: <span style=\"font-weight:bold;\">%accessors%</span></div>";
     private static final String ADMIN_ID = "administrator";
     Plugin dynmap;


### PR DESCRIPTION
I only added one single "<" char to the HTML output in order to fix some display issue in the browser. 

Also updated maven plugin config in order to build (was outdated) and bumped version number. 
